### PR TITLE
Fix dealer card accumulation

### DIFF
--- a/NEW/lib/logic/card_handler.py
+++ b/NEW/lib/logic/card_handler.py
@@ -33,6 +33,9 @@ class CardHandler:
             return "Unknown"
 
     def capture_dealer_cards(self, image, model):
+        # Clear previously detected dealer cards to avoid accumulating cards
+        # from earlier predictions.
+        self.dealer_cards.clear()
         image.save(constants.OUTPUT_DEBUG_IMAGE_PATH)
 
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as temp_file:


### PR DESCRIPTION
## Summary
- clear stored dealer cards before each capture

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841775e0c08832ebcbbc26dc9eb1adc