### PR TITLE
Improve UI performance and layout

### DIFF
--- a/NEW/lib/common/constants.py
+++ b/NEW/lib/common/constants.py
@@ -1,6 +1,7 @@
 VERSION = "1.9"
 TITLE = f"Blackjack AI - v{VERSION}"
-SIZE = "1200x1000"
+# Increased width to allow all player boxes to fit on screen comfortably
+SIZE = "1600x1000"
 RESOLUTION = "2560x1440"
 
 # Font configuration

--- a/NEW/lib/interfaces/gui.py
+++ b/NEW/lib/interfaces/gui.py
@@ -75,23 +75,24 @@ class GraphicalUserInterface(tk.Tk):
         self.action_frame.grid(row=1, column=0, sticky="ew", pady=(0, 10))
 
         self.pbox_gen_button = ttk.Button(
-            self.action_frame,
+            self,
             text="Generate Player Boxes",
-            command=self.pbox_generator.generate,
+            command=self.pbox_generator.generate_async,
             state=tk.DISABLED,
         )
-        self.pbox_gen_button.grid(row=0, column=0, pady=5, sticky="ew")
+        # Position screenshot button at the bottom-right corner of the window
+        self.pbox_gen_button.place(relx=1.0, rely=1.0, anchor="se", x=-10, y=-10)
 
         self.start_button = ttk.Button(self.action_frame, text="Start", command=self.start)
-        self.start_button.grid(row=1, column=0, pady=5, sticky="ew")
+        self.start_button.grid(row=0, column=0, pady=5, sticky="ew")
 
         self.reset_button = ttk.Button(self.action_frame, text="Reset Round", command=self.reset_round)
-        self.reset_button.grid(row=2, column=0, pady=5, sticky="ew")
+        self.reset_button.grid(row=1, column=0, pady=5, sticky="ew")
 
         self.refresh_button = ttk.Button(
             self.action_frame, text="Refresh Counters", command=self.force_refresh_counters
         )
-        self.refresh_button.grid(row=3, column=0, pady=5, sticky="ew")
+        self.refresh_button.grid(row=2, column=0, pady=5, sticky="ew")
 
         self.counter_container = ttk.LabelFrame(self.left_frame, text="Card Counters")
         self.counter_container.grid(row=2, column=0, sticky="nsew")
@@ -148,15 +149,32 @@ class GraphicalUserInterface(tk.Tk):
         self.status_var.set(message)
 
     def draw_canvas(self):
-        self.canvas.create_rectangle(50, 50, 200, 100, fill="black", outline="white")
-        self.canvas.create_text(125, 75, text="Dealer", fill="white")
+        import math
+
+        self.canvas.delete("all")
+        self.update_idletasks()
+        width = self.canvas.winfo_width()
+        height = self.canvas.winfo_height()
+
+        dealer_x = width / 2
+        dealer_y = 80
+        self.canvas.create_rectangle(dealer_x - 75, dealer_y - 40, dealer_x + 75, dealer_y, fill="black", outline="white")
+        self.canvas.create_text(dealer_x, dealer_y - 20, text="Dealer", fill="white")
+
+        radius = 300
+        start_angle = -60
+        angle_step = 120 / 6
+
         for i in range(7):
-            x1 = 50 + i * (constants.CARD_WIDTH + constants.CARD_SPACING)
-            y1 = 150
+            angle = math.radians(start_angle + angle_step * i)
+            x_center = dealer_x + radius * math.cos(angle)
+            y_center = dealer_y + 150 + radius * math.sin(angle)
+            x1 = x_center - constants.CARD_WIDTH / 2
+            y1 = y_center - constants.CARD_HEIGHT / 2
             x2 = x1 + constants.CARD_WIDTH
             y2 = y1 + constants.CARD_HEIGHT
             self.canvas.create_rectangle(x1, y1, x2, y2, outline="black")
-            self.canvas.create_text((x1 + x2) // 2, y2 + 30, text=f"Player {i + 1}", fill="black")
+            self.canvas.create_text((x1 + x2) / 2, y2 + 20, text=f"Player {i + 1}", fill="black")
 
     def populate_monitors(self):
         monitors = screeninfo.get_monitors()

--- a/NEW/lib/logic/blackjack.py
+++ b/NEW/lib/logic/blackjack.py
@@ -472,7 +472,8 @@ class BlackjackLogic:
                 if card == '-':
                     card = "default"
 
-                photo_img = self.get_card_image(card)
+                # Use cached images to avoid disk overhead
+                photo_img = self.get_cached_card_image(card)
                 card_label = tk.Label(self.gui.canvas, image=photo_img, bg="white")
                 card_label.image = photo_img
                 card_label.place(x=start_x, y=card_display_y)
@@ -605,16 +606,14 @@ class BlackjackLogic:
             def finish_update():
                 self.update_gui()
 
-            # Optional: sleep to smooth things out (remove if not needed)
-            time.sleep(0.05)
-
+            # Immediately schedule UI update for snappier feedback
             self.gui.after(0, finish_update)
 
         threading.Thread(target=do_replacement, daemon=True).start()
 
     def refresh_player_card_image(self, player_index, card_index, card_name):
         try:
-            photo_img = self.get_card_image(card_name)
+            photo_img = self.get_cached_card_image(card_name)
             label_index = player_index * 2 + card_index
             if 0 <= label_index < len(self.player_cards_labels):
                 card_label = self.player_cards_labels[label_index]
@@ -664,7 +663,8 @@ class BlackjackLogic:
         placeholder_img = self.get_card_image("default")
         self.dealer_card_label = tk.Label(self.gui.canvas, image=placeholder_img, bg="white")
         self.dealer_card_label.image = placeholder_img
-        self.dealer_card_label.place(relx=0.5, rely=0.1, anchor="center")
+        # Display dealer card slightly higher for clarity
+        self.dealer_card_label.place(relx=0.5, rely=0.07, anchor="center")
         self.dealer_card_label.bind("<Button-1>", lambda e: self.on_dealer_card_click())
 
     def get_card_image(self, card):

--- a/NEW/lib/player_boxes/generator.py
+++ b/NEW/lib/player_boxes/generator.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 import tkinter as tk
+import threading
 
 from PIL import Image, ImageTk
 from tkinter import messagebox
@@ -16,21 +17,31 @@ class PlayerBoxGenerator:
         self.model_players = Utils.initialize_player_model(self)
         self.current_image_path = None
         self.monitor_utils = MonitorUtils()
+        self._thread_lock = threading.Lock()
 
     def set_monitor(self, monitor):
         self.monitor_utils.set_monitor(monitor)
 
-    def generate(self):
-        if not self.monitor_utils.monitor:
-            messagebox.showerror("Error", "Monitor not selected.")
+    def generate_async(self):
+        # Run generation in a background thread to keep the UI responsive
+        if self._thread_lock.locked():
             return
+        threading.Thread(target=self._generate, daemon=True).start()
 
-        current_resolution = self._capture_screen_and_predict()
-        scale_x, scale_y = self.monitor_utils.get_scaling_factors(constants.BASE_RESOLUTION, current_resolution)
-        player_regions = self.monitor_utils.scale_player_regions(constants.BASE_PLAYER_REGIONS, scale_x, scale_y)
-        self._draw_player_regions_on_image(constants.OUTPUT_PREDICTION_PATH, player_regions)
-        self.current_image_path = constants.OUTPUT_FINAL_PREDICTION_PATH
-        self._display_image(self.current_image_path)
+    def _generate(self):
+        with self._thread_lock:
+            if not self.monitor_utils.monitor:
+                messagebox.showerror("Error", "Monitor not selected.")
+                return
+
+            self.gui.set_status("Capturing screenshot...")
+            current_resolution = self._capture_screen_and_predict()
+            scale_x, scale_y = self.monitor_utils.get_scaling_factors(constants.BASE_RESOLUTION, current_resolution)
+            player_regions = self.monitor_utils.scale_player_regions(constants.BASE_PLAYER_REGIONS, scale_x, scale_y)
+            self._draw_player_regions_on_image(constants.OUTPUT_PREDICTION_PATH, player_regions)
+            self.current_image_path = constants.OUTPUT_FINAL_PREDICTION_PATH
+            self.gui.after(0, lambda: self._display_image(self.current_image_path))
+            self.gui.set_status("Player boxes generated")
 
     def _capture_screen_and_predict(self):
         img = self.monitor_utils.capture_screen()

--- a/TASKS.md
+++ b/TASKS.md
@@ -11,3 +11,8 @@
 - [ ] Display player decisions in a dedicated frame
 - [ ] Optimize screenshot generation and card replacement to reduce lag
 - [ ] Increase window width and reposition components: screenshot button bottom-right, dealer card centered, and player boxes laid out in a gentle curve
+
+- [ ] Profile UI operations and cache screenshot/images to improve responsiveness
+- [ ] Implement asynchronous screenshot capture and card updates on separate thread
+- [ ] Revise layout for wider window and curved player arrangement with screenshot button bottom-right
+- [ ] Move dealer card display to a centered position above players


### PR DESCRIPTION
## Summary
- expand window width in constants
- move screenshot button to bottom right and load asynchronously
- draw player boxes in a gentle curve and cache card images
- place dealer card higher for clarity

## Testing
- `pip install -r requirements.txt --use-deprecated=legacy-resolver`
- `pytest -q` *(fails: ProxyError reaching Roboflow API)*

------
https://chatgpt.com/codex/tasks/task_e_6841dcc6f7f8832ebaca8c1270819c4e